### PR TITLE
fix: render the four verdict states the server actually sends

### DIFF
--- a/src/striffs.js
+++ b/src/striffs.js
@@ -7480,6 +7480,12 @@
         background:rgba(255,235,233,.5);
       }
       .striffs-arch-review-panel__rule--pass{ border-left-color:rgba(26,127,55,.45); }
+      /* Already broken before this PR. Amber rather than red: the rule is genuinely broken, so it
+         must not read as a pass, but nothing here is this author's doing. */
+      .striffs-arch-review-panel__rule--stale{
+        border-left-color:rgba(154,103,0,.5);
+        background:rgba(255,248,197,.35);
+      }
       /* Advisory rows are deliberately colourless: any pass/fail palette would read as a verdict,
          and nothing verified these. */
       .striffs-arch-review-panel__rule--advisory{ border-left-color:rgba(110,118,129,.35); }
@@ -8538,8 +8544,16 @@
    * on filtering for a `tier` and a `RAISED` status that no longer arrive -- so every row, including
    * violations, rendered as "nothing stood out".
    *
-   * "Couldn't tell" must stay distinct from "not broken". Folding the two would turn an abstention
-   * into a clean bill of health, in the one place a reader would most trust it.
+   * Four states, because the server sends four. An earlier revision here collapsed this to a binary
+   * on the premise that "the server drops rules that govern nothing in the change before they reach
+   * a verdict". That premise is wrong: `touchesChange` is a FIELD on the verdict, and only the
+   * GitHub check-run formatter filters on it -- `AIReviewController` and `StriffResponseAssembler`
+   * both hand this payload the complete record. A scrapy review sends 15 UNCLEAR rows out of 20, and
+   * under the binary every one of them rendered "not broken by this change".
+   *
+   * "Couldn't tell" must stay distinct from "not broken", and "already broken" from both. Folding
+   * any of them into the pass state turns an abstention, or a live violation, into a clean bill of
+   * health in the one place a reader would most trust it.
    *
    * Absent entirely when no statements were checked -- an empty section implies the docs were
    * consulted and found silent, which is a different claim from not having consulted them.
@@ -8548,19 +8562,27 @@
     const verdicts = Array.isArray(result?.docFactVerdicts) ? result.docFactVerdicts.filter(Boolean) : [];
     if (verdicts.length === 0) return "";
 
-    // Violations first: the reason anyone reads this.
-    const sorted = verdicts.slice().sort((a, b) =>
-      Number(b.status === "VIOLATED") - Number(a.status === "VIOLATED"));
+    // Most actionable first: what this PR broke, then what was already broken, then what holds,
+    // then what could not be checked.
+    const ORDER = { VIOLATED: 0, PRE_EXISTING: 1, MAINTAINED: 2, UNCLEAR: 3 };
+    const rank = v => (v.status in ORDER ? ORDER[v.status] : ORDER.UNCLEAR);
+    const sorted = verdicts.slice().sort((a, b) => rank(a) - rank(b));
 
     const html = sorted.map(v => {
       const violated = v.status === "VIOLATED";
+      const alreadyBroken = v.status === "PRE_EXISTING";
       const held = v.status === "MAINTAINED";
-      const modifier = violated ? "fail" : (held ? "pass" : "advisory");
-      const verdict = violated
-        ? "❌ broken by this change"
-        : (held ? "✅ not broken by this change" : "💭 couldn't tell");
-      const detail = violated && Array.isArray(v.evidence) && v.evidence.length > 0
-        ? v.evidence[0]
+      // An unrecognised status falls in with "couldn't tell" rather than with "holds": a server
+      // that grows a fifth outcome must not have it render as a pass here.
+      const modifier = violated ? "fail" : alreadyBroken ? "stale" : held ? "pass" : "advisory";
+      const verdict = violated ? "❌ broken by this change"
+        : alreadyBroken ? "⚠️ already broken, not by this PR"
+        : held ? "✅ holds"
+        : "💭 couldn't check";
+      // A pre-existing violation carries its witnessing edges too -- they are the whole value of
+      // the row. The last entry is the edge; the first is the explanatory note.
+      const detail = (violated || alreadyBroken) && Array.isArray(v.evidence) && v.evidence.length > 0
+        ? v.evidence[v.evidence.length - 1]
         : v.quote;
       return `<div class="striffs-arch-review-panel__rule striffs-arch-review-panel__rule--${modifier}">
           <div class="striffs-arch-review-panel__rule-head">
@@ -8574,7 +8596,7 @@
 
     return `<div class="striffs-arch-review-panel__section">
       <div class="striffs-arch-review-panel__section-title">Documented Rules</div>
-      <div class="striffs-arch-review-panel__section-note">Rules quoted from this repository's own docs, judged against what this PR changes. This is striff's reading, not a proof — and it only sees the change, so a rule shown as held here may already be broken elsewhere.</div>
+      <div class="striffs-arch-review-panel__section-note">Rules quoted from this repository's own docs and checked against the dependency graph this PR produces. A rule shown as holding was not broken anywhere in that graph; one shown as already broken was broken before this PR too.</div>
       ${html}
     </div>`;
   }
@@ -10553,6 +10575,16 @@
                 quote: 'Manual smoke intention quote.',
                 status: 'UNCLEAR',
                 evidence: []
+              },
+              {
+                factId: 'manual-d3',
+                subject: 'com.manual.smoke.legacy',
+                statement: 'manual smoke pre-existing drift',
+                sourceDocPath: 'docs/manual-smoke.md',
+                quote: 'Manual smoke pre-existing quote.',
+                status: 'PRE_EXISTING',
+                evidence: ['already broken before this change; this change did not add to it',
+                  'com.manual.smoke.legacy.Old -> com.manual.smoke.Beta']
               }
             ]
           });

--- a/test/arch-review-panel.js
+++ b/test/arch-review-panel.js
@@ -65,7 +65,7 @@ const FLAGGED_WITH_DOCS = {
     { factId: 'd1', subject: 'com.app.domain', statement: 'domain must not depend on infrastructure', sourceDocPath: 'docs/architecture/adr-001-layering.md', quote: 'The domain layer must not depend on infrastructure.', status: 'MAINTAINED', evidence: [] },
     { factId: 'd2', subject: 'com.app.web', statement: 'web must not reach the persistence layer directly', sourceDocPath: 'docs/architecture.md', quote: 'Controllers talk to services, never to repositories.', status: 'VIOLATED', evidence: ['com.app.web.OrderController -> com.app.persistence.OrderRepository'] },
     { factId: 'd3', subject: 'com.app.billing', statement: 'billing owns all money arithmetic', sourceDocPath: 'docs/invariants.md', quote: 'All money arithmetic lives in billing.', status: 'UNCLEAR', evidence: [] },
-    { factId: 'd4', subject: 'com.app.audit', statement: 'every mutation writes an audit record', sourceDocPath: 'docs/invariants.md', quote: 'Every mutation writes an audit record.', status: 'UNCLEAR', evidence: [] }
+    { factId: 'd4', subject: 'com.app.audit', statement: 'every mutation writes an audit record', sourceDocPath: 'docs/invariants.md', quote: 'Every mutation writes an audit record.', status: 'PRE_EXISTING', evidence: ['already broken before this change; this change did not add to it', 'com.app.audit.Writer -> com.app.web.Session'] }
   ]
 };
 
@@ -140,15 +140,23 @@ const XSS = {
     const { text } = await render(FLAGGED_WITH_DOCS);
     check('renders the surfaced item', text.includes('New package cycle'));
     check('renders a documented-rule violation', text.includes('❌ broken by this change'));
-    check('renders a rule the change did not break', text.includes('✅ not broken by this change'));
+    check('renders a rule the change did not break', text.includes('✅ holds'));
     check('violations sort above the rules that held',
-      text.indexOf('❌ broken by this change') < text.indexOf('✅ not broken by this change'));
-    // The row that would be cheapest to fold away and most expensive to get wrong: an abstention
-    // shown as a clean bill of health is the failure this section can least afford.
-    check("an unclear verdict is not rendered as held", text.includes("💭 couldn't tell"));
-    check('the section says it is a reading, not a proof', text.includes('not a proof'));
-    check('the section says it only saw the change',
-      text.includes('may already be broken elsewhere'));
+      text.indexOf('❌ broken by this change') < text.indexOf('✅ holds'));
+    // The two rows that are cheapest to fold into the pass state and most expensive to get wrong.
+    // An abstention or a live violation shown as a clean bill of health is the failure this
+    // section can least afford -- and a previous revision made exactly that trade, on the false
+    // premise that the server filters these out before they arrive. It does not: a scrapy review
+    // sends 15 UNCLEAR rows out of 20.
+    check("an unclear verdict is not rendered as held", text.includes("💭 couldn't check"));
+    check('a pre-existing violation is not rendered as held',
+      text.includes('⚠️ already broken, not by this PR'));
+    check('a pre-existing violation names the edge that breaks it',
+      text.includes('com.app.audit.Writer -> com.app.web.Session'));
+    check('already-broken sorts above the rules that held',
+      text.indexOf('⚠️ already broken') < text.indexOf('✅ holds'));
+    check('the section says it checked the dependency graph',
+      text.includes('dependency graph this PR produces'));
     check('flagged check counts both buckets', text.includes('❗ 1 flagged · 👀 1 observation'));
     check('doc rules render above structural checks', text.indexOf('DOCUMENTED RULES') < text.indexOf('STRUCTURAL CHECKS'));
     check('source doc shown as basename only', text.includes('adr-001-layering.md') && !text.includes('docs/architecture/adr-001'));


### PR DESCRIPTION
The panel treated the documented-rule verdict as **binary** — `VIOLATED` or not — so every other status rendered *"not broken by this change"*.

## The premise was wrong

An earlier revision made that collapse deliberately, reasoning that *"the server drops rules that govern nothing in the change before they reach a verdict"*. It does not.

`touchesChange` is a **field on the verdict, not a filter**. Only `CheckRunFormatter` filters on it — `AIReviewController` and `StriffResponseAssembler` both hand this payload `DocArchitectureReviewer`'s complete record, `UNCLEAR` rows included. **A scrapy review sends 15 `UNCLEAR` out of 20 verdicts**, and under the binary every one of them rendered as a clean bill of health — in the one place a reader would most trust it.

That revision also deleted the regression test guarding this, whose own comment called it *"the row that would be cheapest to fold away and most expensive to get wrong"*. It is restored here, with one test per state.

## The server also grew a fourth status

`PRE_EXISTING` — a rule the repository already breaks. Not this PR's doing, and emphatically not a pass. Under the binary it would have rendered green too.

| status | rendering | |
|---|---|---|
| `VIOLATED` | ❌ broken by this change | red |
| `PRE_EXISTING` | ⚠️ already broken, not by this PR | amber, carries the edge |
| `MAINTAINED` | ✅ holds | green |
| `UNCLEAR` | 💭 couldn't check | colourless |

An **unrecognised status now falls in with "couldn't check"** rather than with "holds", so a server that grows a fifth outcome cannot render it as a pass here.

The section note no longer says a held rule *"may already be broken elsewhere"*: already-broken is its own row now, so holding means not broken anywhere in the graph this PR produces, and the old caveat understates the check.

## Verification

**40 unit tests + 28 panel checks pass.** The manual-smoke fixture exercises all four states, restoring an assertion on `rule--advisory` that the binary revision had left dead.

> Pairs with [striff-api#109](https://github.com/hadi-technology/striff-api/pull/109), which introduces `PRE_EXISTING`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017X3m5Qxtn8KZPM6TqrknGk
